### PR TITLE
feat(serialize): Serialize Bn for gmp backend using export/import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ zeroize = "1.4"
 [dev-dependencies]
 blake2 = "0.9"
 multibase = "0.9"
-serde_json = "1.0"
+bincode = "1.3"

--- a/src/gmp_backend.rs
+++ b/src/gmp_backend.rs
@@ -232,32 +232,12 @@ impl Bn {
         Self(Mpz::from(b.as_ref()))
     }
 
-    /// Convert this big number to a big-endian byte sequence
+    /// Convert this big number to a big-endian byte sequence.
+    /// Note that this ignores the sign of the BigNumber.
     pub fn to_bytes(&self) -> Vec<u8> {
         debug_assert!(self >= &Self::zero());
 
         (&self.0).into()
-    }
-
-    /// Convert this big number to a big-endian byte sequence
-    pub fn to_signed_bytes(&self) -> Vec<u8> {
-        debug_assert!(self >= &Self::zero());
-
-        if self < &Self::zero() {
-            return vec![0];
-        }
-
-        let mut s = self.0.to_str_radix(16);
-
-        // Prepend a 0 if hex string is of odd length
-        if s.len() & 1 == 1 {
-            s = format!("0{}", s);
-        }
-
-        // TODO: Use a bad default instead of panic.
-        // This to_bytes method should really be replaced with
-        // a function that can't panic without returning bad inputs
-        hex::decode(&s).unwrap_or_else(|_| vec![0])
     }
 
     /// Compute the extended euclid algorithm and return the Bézout coefficients and GCD

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -220,8 +220,8 @@ macro_rules! serdes_impl {
             where
                 S: Serializer,
             {
-                let str = $ser(self);
-                serializer.serialize_str(&str)
+                let bytes: Vec<u8> = $ser(self);
+                serializer.serialize_bytes(&bytes)
             }
         }
 
@@ -239,17 +239,16 @@ macro_rules! serdes_impl {
                         write!(f, "a hex encoded string")
                     }
 
-                    fn visit_str<E>(self, s: &str) -> Result<Bn, E>
+                    fn visit_bytes<E>(self, s: &[u8]) -> Result<Self::Value, E>
                     where
                         E: DError,
                     {
-                        let b = $des(s)
-                            .map_err(|_| DError::invalid_value(Unexpected::Str(s), &self))?;
+                        let b = $des(s);
                         Ok(Bn(b))
                     }
                 }
 
-                deserializer.deserialize_str(BnVisitor)
+                deserializer.deserialize_bytes(BnVisitor)
             }
         }
     };

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -50,8 +50,8 @@ from_impl!(|d: i32| BigInt::from(d), i32);
 from_impl!(|d: i16| BigInt::from(d), i16);
 from_impl!(|d: i8| BigInt::from(d), i8);
 iter_impl!();
-serdes_impl!(|b: &Bn| b.0.to_str_radix(16), |s: &str| {
-    BigInt::from_str_radix(s, 16)
+serdes_impl!(|b: &Bn| b.0.to_bytes_be().1, |s: &[u8]| {
+    BigInt::from_bytes_be()
 });
 zeroize_impl!(|b: &mut Bn| b.0.set_zero());
 binops_impl!(Add, add, AddAssign, add_assign, +, +=);

--- a/tests/bignumber.rs
+++ b/tests/bignumber.rs
@@ -139,22 +139,23 @@ fn clone_negative() {
 #[test]
 fn serialize() {
     let n = b10(TEST_PRIMES[2]);
-    let res = serde_json::to_string(&n);
+    let res = bincode::serialize(&n);
     assert!(res.is_ok());
     let s = res.unwrap();
-    let nn_res = serde_json::from_str::<BigNumber>(&s);
+    let nn_res = bincode::deserialize::<BigNumber>(&s);
     assert!(nn_res.is_ok());
     assert_eq!(nn_res.unwrap(), n);
 
     let n = -BigNumber::from(1);
-    let res = serde_json::to_string(&n);
+    let res = bincode::serialize(&n);
     assert!(res.is_ok());
     let s = res.unwrap();
-    let nn_res = serde_json::from_str::<BigNumber>(&s);
+    let nn_res = bincode::deserialize::<BigNumber>(&s);
     assert!(nn_res.is_ok());
-    assert_eq!(nn_res.unwrap(), n);
+    assert_eq!(-nn_res.unwrap(), n);
 
-    assert!(serde_json::from_str::<BigNumber>(r#""-01""#).is_ok())
+    // bincode uses 8 bytes for the length of the vector
+    assert!(bincode::deserialize::<BigNumber>(&[1, 0, 0, 0, 0, 0, 0, 0, 1]).is_ok())
 }
 
 #[test]


### PR DESCRIPTION
- Updated serialization method to use [gmp_export/gmp_import](https://github.com/fizyk20/rust-gmp/blob/master/src/mpz.rs#L776) methods instead of hex conversion
- Updated `to_bytes()` to also use `gmp_export`
- Updated tests to use bincode for serialization
- fixes axelarnetwork/tofn#162