### PR TITLE
Update rust backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.2.3"
 [features]
 default = ["rust"]
 gmp = ["hex", "rand/default", "rust-gmp"]
-rust = ["glass_pumpkin", "num-bigint", "num-integer", "num-traits", "rand"]
+rust = ["glass_pumpkin", "num-bigint", "num-integer", "num-traits", "rand/getrandom"]
 wasm = ["getrandom", "rand", "wasm-bindgen"]
 
 [dependencies]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -327,7 +327,7 @@ macro_rules! wasm_slice_impl {
             unsafe fn from_abi(js: Self::Abi) -> Self {
                 let ptr = <*mut u8>::from_abi(js.ptr);
                 let len = js.len as usize;
-                let r = std::slice::from_raw_parts(ptr, len);
+                let r = core::slice::from_raw_parts(ptr, len);
                 $name::from_slice(&r)
             }
         }
@@ -344,7 +344,7 @@ macro_rules! wasm_slice_impl {
             }
         }
 
-        impl std::convert::TryFrom<wasm_bindgen::JsValue> for $name {
+        impl core::convert::TryFrom<wasm_bindgen::JsValue> for $name {
             type Error = &'static str;
 
             fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -4,15 +4,12 @@
 */
 use crate::{get_mod, GcdResult};
 use glass_pumpkin::{prime, safe_prime};
-use num_bigint::{BigInt, Sign, ToBigInt};
+use num_bigint::{BigInt, BigUint, Sign};
 use num_integer::Integer;
-use num_traits::{
-    identities::{One, Zero},
-    Num,
-};
-use rand::RngCore;
+use num_traits::identities::{One, Zero};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 use serde::{
-    de::{Error as DError, Unexpected, Visitor},
+    de::{Error as DError, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
@@ -224,9 +221,7 @@ impl Bn {
 
     /// Generate a random value less than `n`
     pub fn random(n: &Self) -> Self {
-        let mut rng = rand::thread_rng();
-
-        Self::random_with_rng(&mut rng, n)
+        Self::random_with_rng(&mut OsRng, n)
     }
 
     /// Generate a random value less than `n` with the provided `rng`
@@ -307,16 +302,34 @@ impl Bn {
         }
     }
 
-    /// Generate a safe prime with `size` bits
-    pub fn safe_prime(size: usize) -> Self {
-        let p = safe_prime::new(size).unwrap();
-        Self(p.to_bigint().unwrap())
-    }
-
     /// Generate a prime with `size` bits
     pub fn prime(size: usize) -> Self {
-        let p = prime::new(size).unwrap();
-        Self(p.to_bigint().unwrap())
+        Self::prime_with_rng(&mut OsRng, size)
+    }
+
+    /// Generate a safe prime with `size` bits
+    pub fn safe_prime(size: usize) -> Self {
+        Self::safe_prime_with_rng(&mut OsRng, size)
+    }
+
+    /// Generate a prime with `size` bits with a user-provided rng
+    pub fn prime_with_rng(rng: &mut (impl CryptoRng + RngCore), size: usize) -> Self {
+        let p = prime::from_rng(size, rng).unwrap();
+        Self(p.into())
+    }
+
+    /// Generate a safe prime with `size` bits
+    pub fn safe_prime_with_rng(rng: &mut (impl CryptoRng + RngCore), bitsize: usize) -> Self {
+        let p = safe_prime::from_rng(bitsize, rng).unwrap();
+        Self(p.into())
+    }
+
+    /// Generate a safe prime with `size - 1` or `size` bits using a user-provided rng
+    pub fn fast_safe_prime_with_rng(rng: &mut (impl CryptoRng + RngCore), bitsize: usize) -> Self {
+        // Since the bitsize here is relaxed, we could implement the same strategy
+        // as in gmp_backend, but it does not seem to lead to any performance improvement.
+        let p = safe_prime::from_rng(bitsize, rng).unwrap();
+        Self(p.into())
     }
 
     /// True if a prime number
@@ -336,9 +349,8 @@ impl Bn {
 
 #[test]
 fn safe_prime() {
-    let n = Bn::safe_prime(128);
-    // TODO: Rust backend samples a prime from (0, 2^(n+1)) and so doesn't guarantee the bit length
-    assert!(n.bit_length() <= 128 + 1);
+    let n = Bn::safe_prime(256);
+    assert!(n.bit_length() == 256);
     assert!(n.is_prime());
     let sg: Bn = n >> 1;
     assert!(sg.is_prime())

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -51,7 +51,8 @@ from_impl!(|d: i16| BigInt::from(d), i16);
 from_impl!(|d: i8| BigInt::from(d), i8);
 iter_impl!();
 serdes_impl!(|b: &Bn| b.0.to_bytes_be().1, |s: &[u8]| {
-    BigInt::from_bytes_be()
+    // TODO: this ignores the sign. Fixed in upstream (unknown_order=0.5)
+    BigInt::from_bytes_be(Sign::Plus, s)
 });
 zeroize_impl!(|b: &mut Bn| b.0.set_zero());
 binops_impl!(Add, add, AddAssign, add_assign, +, +=);

--- a/src/rust_backend.rs
+++ b/src/rust_backend.rs
@@ -231,13 +231,19 @@ impl Bn {
 
     /// Generate a random value less than `n` with the provided `rng`
     pub fn random_with_rng(rng: &mut (impl CryptoRng + RngCore), n: &Self) -> Self {
-        let len = (n.0.bits() - 1) / 8;
-        let mut t = vec![0u8; len as usize];
+        let bits = n.0.bits() as usize;
+        let len_bytes = (bits - 1) / 8 + 1;
+        let high_bits = len_bytes * 8 - bits;
+        let mut t = vec![0u8; len_bytes as usize];
         loop {
             rng.fill_bytes(&mut t);
-            let b = BigInt::from_bytes_be(Sign::Plus, &t);
-            if b < n.0 {
-                return Self(b);
+            if high_bits > 0 {
+                t[0] &= u8::MAX >> high_bits;
+            }
+            let b = BigUint::from_bytes_be(&t);
+            let res = Self(b.into());
+            if res.0 < n.0 {
+                return res;
             }
         }
     }


### PR DESCRIPTION
This PR aims at making the library usable in a no-std and WASM environment.

Changes:
- Rust backend made no-std compatible (using `OsRng` as the RNG, which, while different from `thread_rng` used by GMP backend, does not constitute a change of behavior, since that's what `glass_pumpkin` uses anyway).
- Fixed `serdes_impl!` call.
- Fixed a bug in `random_with_rng` (the randoms generated were too small if the requested bitsize wasn't a multiple of 8).
- Added `fast_safe_prime_with_rng` to mimic the one provided by the GMP backend.

Alternatively, it may be a better strategy to apply this to https://github.com/mikelodder7/unknown_order which is at version 0.5 already and switch https://github.com/axelarnetwork/paillier-rs to work with it.